### PR TITLE
Feature/publish artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,5 +38,11 @@ gradlePlugin {
             description = 'Plugin which assists in building Garmin barrels on Gradle'
             implementationClass = 'com.chesapeaketechnology.gradle.plugins.garmin.GradleGarminBarrelPlugin'
         }
+        garminPublishPlugin {
+            id = 'com.chesapeaketechnology.garmin-publish-plugin'
+            displayName = 'Garmin Publish Plugin'
+            description = 'Plugin which assists in publishing Garmin artifacts to Maven repos'
+            implementationClass = 'com.chesapeaketechnology.gradle.plugins.garmin.GarminPublishPlugin'
+        }
     }
 }

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/BaseGarminPlugin.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/BaseGarminPlugin.java
@@ -19,7 +19,6 @@ abstract class BaseGarminPlugin implements Plugin<Project>
 {
     private final String GARMIN_SDK_HOME = "GARMIN_SDK_HOME";
     private final String GARMIN_GROUP = "garmin";
-    public static final String BUILD_GARMIN = "buildGarmin";
 
     @Override
     public void apply(Project project)

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/BaseGarminPlugin.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/BaseGarminPlugin.java
@@ -18,6 +18,8 @@ import java.util.stream.Collectors;
 abstract class BaseGarminPlugin implements Plugin<Project>
 {
     private final String GARMIN_SDK_HOME = "GARMIN_SDK_HOME";
+    private final String GARMIN_GROUP = "garmin";
+    public static final String BUILD_GARMIN = "buildGarmin";
 
     @Override
     public void apply(Project project)
@@ -52,7 +54,7 @@ abstract class BaseGarminPlugin implements Plugin<Project>
 
         BaseGarminTask buildGarminTask = project.getTasks().create(taskName, taskClazz);
         buildGarminTask.setJungleFiles(extension.getJungleFiles().stream().map(File::new).collect(Collectors.toList()));
-
+        buildGarminTask.setGroup(GARMIN_GROUP);
         if (extension.getSdkDirectory() != null)
         {
             buildGarminTask.setSdkDirectory(new File(extension.getSdkDirectory()));

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GarminPublishPlugin.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GarminPublishPlugin.java
@@ -42,11 +42,7 @@ public class GarminPublishPlugin implements Plugin<Project>
                 throw new GradleException("Unable to find Garmin build task.");
             }
 
-            Task publishToMavenLocal = project.getTasks().findByPath("publishToMavenLocal");
-            if (publishToMavenLocal != null)
-            {
-                publishToMavenLocal.dependsOn(baseGarminTask);
-            }
+            setPublishingDependsOn(project, baseGarminTask);
 
             proj.getExtensions().configure(PublishingExtension.class, publishing -> publishing.publications(publications -> {
                         baseGarminTask.getGeneratedArtifacts().forEach(file -> {
@@ -67,6 +63,20 @@ public class GarminPublishPlugin implements Plugin<Project>
                     }
             ));
         });
+    }
+
+    private void setPublishingDependsOn(Project project, BaseGarminTask task)
+    {
+        Task publishToMavenLocal = project.getTasks().findByPath("publishToMavenLocal");
+        if (publishToMavenLocal != null)
+        {
+            publishToMavenLocal.dependsOn(task);
+        }
+
+        Task publish = project.getTasks().findByPath("publish");
+        if(publish != null) {
+            publish.dependsOn(task);
+        }
     }
 
     private String getNameFromFile(File file, boolean isApp)

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GarminPublishPlugin.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GarminPublishPlugin.java
@@ -1,0 +1,87 @@
+package com.chesapeaketechnology.gradle.plugins.garmin;
+
+import com.chesapeaketechnology.gradle.plugins.garmin.tasks.BaseGarminTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
+
+import java.io.File;
+import java.util.Optional;
+
+public class GarminPublishPlugin implements Plugin<Project>
+{
+    @Override
+    public void apply(Project project)
+    {
+        project.getPlugins().apply(MavenPublishPlugin.class);
+
+        project.afterEvaluate(proj -> {
+            boolean hasBarrelPlugin = proj.getPlugins().hasPlugin(GradleGarminBarrelPlugin.class);
+            boolean hasAppPlugin = proj.getPlugins().hasPlugin(GradleGarminAppPlugin.class);
+
+            if (!hasAppPlugin && !hasBarrelPlugin)
+            {
+                throw new GradleException("Unable to find any Garmin Gradle plugins.");
+            }
+
+            final BaseGarminTask baseGarminTask = (BaseGarminTask) proj.getTasks().findByName(
+                    hasAppPlugin ? GradleGarminAppPlugin.BUILD_GARMIN_APP : GradleGarminBarrelPlugin.BUILD_GARMIN_BARREL);
+
+            if (baseGarminTask == null)
+            {
+                throw new GradleException("Unable to find Garmin build task.");
+            }
+
+            Task publishToMavenLocal = project.getTasks().findByPath("publishToMavenLocal");
+            if (publishToMavenLocal != null)
+            {
+                publishToMavenLocal.dependsOn(baseGarminTask);
+            }
+
+            proj.getExtensions().configure(PublishingExtension.class, publishing -> publishing.publications(publications -> {
+                baseGarminTask.getGeneratedArtifacts().forEach(file -> {
+                            final String name = getNameFromFile(file, hasAppPlugin);
+                            publications.create(
+                                    name,
+                                    MavenPublication.class, mavenPublication -> mavenPublication.artifact(file,
+                                            mavenArtifact -> {
+                                                mavenArtifact.builtBy(baseGarminTask);
+                                                mavenArtifact.setExtension(getExtensionByStringHandling(file.getName()).orElse(""));
+                                                if (hasAppPlugin)
+                                                {
+                                                    //find the device name to set the classifier
+                                                    mavenArtifact.setClassifier(name);
+                                                }
+                                            }))
+                                    .setArtifactId(baseGarminTask.getOutName());
+                        });
+                    }
+            ));
+        });
+    }
+
+    private String getNameFromFile(File file, boolean isApp)
+    {
+        String fileName = file.getName();
+
+        if (isApp)
+        {
+            //example file name: app-fenix5plus.prg
+            final String[] split = fileName.split("-");//[app, fenix5plus.prg]
+            fileName = split[split.length - 1]; // fenix5plus.prg
+        }
+
+        return fileName.split("\\.")[0];
+    }
+
+    public Optional<String> getExtensionByStringHandling(String filename)
+    {
+        return Optional.ofNullable(filename)
+                .filter(f -> f.contains("."))
+                .map(f -> f.substring(filename.lastIndexOf(".") + 1));
+    }
+}

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GarminPublishPlugin.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GarminPublishPlugin.java
@@ -19,6 +19,8 @@ public class GarminPublishPlugin implements Plugin<Project>
     {
         project.getPlugins().apply(MavenPublishPlugin.class);
 
+        project.getConfigurations().maybeCreate("barrel");
+
         project.afterEvaluate(proj -> {
             boolean hasBarrelPlugin = proj.getPlugins().hasPlugin(GradleGarminBarrelPlugin.class);
             boolean hasAppPlugin = proj.getPlugins().hasPlugin(GradleGarminAppPlugin.class);
@@ -43,7 +45,7 @@ public class GarminPublishPlugin implements Plugin<Project>
             }
 
             proj.getExtensions().configure(PublishingExtension.class, publishing -> publishing.publications(publications -> {
-                baseGarminTask.getGeneratedArtifacts().forEach(file -> {
+                        baseGarminTask.getGeneratedArtifacts().forEach(file -> {
                             final String name = getNameFromFile(file, hasAppPlugin);
                             publications.create(
                                     name,

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GarminPublishPlugin.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GarminPublishPlugin.java
@@ -12,6 +12,10 @@ import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
 import java.io.File;
 import java.util.Optional;
 
+/**
+ * Gradle plugin which handles creating Garmin configurations and publishing artifacts (barrels/apps)
+ * to local and remote repositories.
+ */
 public class GarminPublishPlugin implements Plugin<Project>
 {
     @Override
@@ -55,7 +59,6 @@ public class GarminPublishPlugin implements Plugin<Project>
                                                 mavenArtifact.setExtension(getExtensionByStringHandling(file.getName()).orElse(""));
                                                 if (hasAppPlugin)
                                                 {
-                                                    //find the device name to set the classifier
                                                     mavenArtifact.setClassifier(name);
                                                 }
                                             }))

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GradleGarminAppPlugin.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GradleGarminAppPlugin.java
@@ -17,7 +17,7 @@ import java.io.File;
 public class GradleGarminAppPlugin extends BaseGarminPlugin
 {
     private static final String GARMIN_APP_EXT = "garminApp";
-    private static final String BUILD_GARMIN_APP = "buildGarminApp";
+    public static final String BUILD_GARMIN_APP = "buildGarminApp";
 
     private static final String DEVELOPER_KEY_ENV = "GARMIN_DEV_KEY";
 

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GradleGarminBarrelPlugin.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/GradleGarminBarrelPlugin.java
@@ -14,7 +14,7 @@ import org.gradle.api.Project;
 public class GradleGarminBarrelPlugin extends BaseGarminPlugin
 {
     private static final String GARMIN_BARREL_EXT = "garminBarrel";
-    private static final String BUILD_GARMIN_BARREL = "buildGarminBarrel";
+    public static final String BUILD_GARMIN_BARREL = "buildGarminBarrel";
 
     @Override
     public void apply(Project project)

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/tasks/BaseGarminTask.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/tasks/BaseGarminTask.java
@@ -1,11 +1,7 @@
 package com.chesapeaketechnology.gradle.plugins.garmin.tasks;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputDirectory;
-import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -37,12 +33,11 @@ public abstract class BaseGarminTask extends DefaultTask
 
     protected static final String SEPARATOR = System.getProperty("file.separator");
 
-    protected static final boolean isWindows = System.getProperty("os.name").contains("Windows") ;
+    protected static final boolean isWindows = System.getProperty("os.name").contains("Windows");
 
     @TaskAction
     void start()
     {
-
         final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
 
         //create the root directory that the binary files will live under
@@ -103,8 +98,10 @@ public abstract class BaseGarminTask extends DefaultTask
     {
         List<String> args = new ArrayList<>();
 
-        args.add("-f");
-        jungleFiles.forEach(file -> args.add(file.getPath()));
+        jungleFiles.forEach(file -> {
+            args.add("-f");
+            args.add(file.getPath());
+        });
 
         args.add("--warn");
 
@@ -138,7 +135,7 @@ public abstract class BaseGarminTask extends DefaultTask
 
     public void setJungleFiles(List<File> jungleFiles)
     {
-        this.jungleFiles = Collections.unmodifiableList(jungleFiles);
+        this.jungleFiles = jungleFiles;
     }
 
     public String getAppName()

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/tasks/BaseGarminTask.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/tasks/BaseGarminTask.java
@@ -62,6 +62,8 @@ public abstract class BaseGarminTask extends DefaultTask
 
     protected abstract void runBuild(File binaryDir, ByteArrayOutputStream byteArrayOutputStream);
 
+    public abstract List<File> getGeneratedArtifacts();
+
     protected void execTask(String execPath, List<String> args, ByteArrayOutputStream os)
     {
         getProject().exec(execSpec -> {

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/tasks/BuildGarminAppTask.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/tasks/BuildGarminAppTask.java
@@ -96,7 +96,7 @@ public class BuildGarminAppTask extends BaseGarminTask
                                     StandardCopyOption.REPLACE_EXISTING);
                         } catch (IOException e)
                         {
-                            e.printStackTrace();
+                            getLogger().error("Unable to copy barrel dependency to the dependency directory!", e);
                         }
                     }
             );
@@ -118,7 +118,7 @@ public class BuildGarminAppTask extends BaseGarminTask
             properties.load(input);
         } catch (IOException ex)
         {
-            ex.printStackTrace();
+            getLogger().error("An error has occurred when attempting to read the default jungle file!", ex);
         }
 
         try (OutputStream outputStream = new FileOutputStream(DEFAULT_JUNGLE_FILE))
@@ -140,7 +140,7 @@ public class BuildGarminAppTask extends BaseGarminTask
             properties.store(outputStream, null);
         } catch (IOException e)
         {
-            e.printStackTrace();
+            getLogger().error("An error has occurred when attempting to write to the default jungle file!", e);
         }
     }
 

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/tasks/BuildGarminAppTask.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/tasks/BuildGarminAppTask.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -59,6 +60,21 @@ public class BuildGarminAppTask extends BaseGarminTask
 
             execTask(sdkDirectory + APP_BUILD, args, byteArrayOutputStream);
         });
+    }
+
+    @Override
+    public List<File> getGeneratedArtifacts()
+    {
+        final String binaryDirectoryPath = getOutputDirectory() + SEPARATOR + getBinaryDirectoryName() + SEPARATOR;
+
+        return devices.stream()
+                .map(deviceStr -> {
+                    final String deviceDirectory = deviceStr + SEPARATOR;
+                    final String PRGFileName = outName + "-" + deviceStr + ".prg";
+                    return new File(binaryDirectoryPath + deviceDirectory + PRGFileName);
+                })
+                .filter(File::exists)
+                .collect(Collectors.toList());
     }
 
     public boolean isParallel()

--- a/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/tasks/BuildGarminBarrelTask.java
+++ b/src/main/java/com/chesapeaketechnology/gradle/plugins/garmin/tasks/BuildGarminBarrelTask.java
@@ -1,9 +1,8 @@
 package com.chesapeaketechnology.gradle.plugins.garmin.tasks;
 
-import org.gradle.api.tasks.Input;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -30,5 +29,13 @@ public class BuildGarminBarrelTask extends BaseGarminTask
         args.add("--output");
         args.add(binaryDir + SEPARATOR + outName + ".barrel");
         execTask(sdkDirectory + BARREL_BUILD, args, byteArrayOutputStream);
+    }
+
+    @Override
+    public List<File> getGeneratedArtifacts()
+    {
+        final String binaryDirectoryPath = getOutputDirectory() + SEPARATOR + getBinaryDirectoryName() + SEPARATOR;
+        File file = new File(binaryDirectoryPath + outName + ".barrel");
+        return file.exists() ? Collections.singletonList(file) : Collections.emptyList();
     }
 }


### PR DESCRIPTION
Initial implementation of the publish feature for barrels and apps. 

- This allows developers to run Gradle publish tasks to publish artifacts to configured repositories.

- Allows developers to use a new "barrel" configuration in Garmin app projects and the plugin handles pulling the barrel dependencies from configured repositories and including them in the build.